### PR TITLE
Fix symlinks in jail guide

### DIFF
--- a/content/post/2015-08-09-freebsd-jails-the-hard-way.md
+++ b/content/post/2015-08-09-freebsd-jails-the-hard-way.md
@@ -201,8 +201,8 @@ mkdir skeleton
 ln -s skeleton/etc etc
 ln -s skeleton/home home
 ln -s skeleton/root root
-ln -s skeleton/usr/local usr/local
-ln -s skeleton/usr/ports/distfiles usr/ports/distfiles
+ln -s  ../skeleton/usr/local usr/local
+ln -s  ../../skeleton/usr/ports/distfiles usr/ports/distfiles
 ln -s skeleton/tmp tmp
 ln -s skeleton/var var
 ```


### PR DESCRIPTION
Description: Fix symlinks in the base directory.
File: content/post/2015-08-09-freebsd-jails-the-hard-way.md